### PR TITLE
using the v2 API to patch matches

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -20,7 +20,7 @@ if(!empty($_GET)) {
     // Get cURL resource
     $curl = curl_init();
 
-    curl_setopt($curl, CURLINFO_HEADER_OUT, true); // enable tracking
+    //curl_setopt($curl, CURLINFO_HEADER_OUT, true); // enable tracking
     
     $data = '{"scheduled_datetime": "'.$date->format(DATE_ISO8601).'"}';
     echo $data;
@@ -53,13 +53,13 @@ if(!empty($_GET)) {
 
 
   
-$headerSent = curl_getinfo($curl, CURLINFO_HEADER_OUT ); // request headers
-echo $headerSent;
-echo $output;
+//$headerSent = curl_getinfo($curl, CURLINFO_HEADER_OUT ); // request headers
+//echo $headerSent;
+//echo $output;
     // Close request to clear up some resources
     curl_close($curl);
 
-    //return json_decode($body);
+    return json_decode($body);
 }
 ?>
 

--- a/oauth.php
+++ b/oauth.php
@@ -40,3 +40,72 @@ function getAccessToken($api_client_id, $api_client_secret, $api_key) {
 
     return @$access_token;
 }
+
+
+// for v2 API, we must now get a score as part of the authorization request 
+/*
+https://developer.toornament.com/v2/security/scopes
+===========================
+Available Scopes
+The Toornament APIs currently supports the following scopes
+participant:manage_registrations
+Grants the ability to manage the registrations of a user.
+participant:manage_participations
+Grants the ability to manage the participations of a user.
+user:info
+Grants access to public user information.
+organizer:view
+Grants the ability to list tournaments and see their settings.
+organizer:admin
+Grants the ability to create a tournament and edit its settings.
+organizer:result
+Grants the ability to edit match information and referee results.
+organizer:participant
+Grants the ability to manage the participants of a tournament.
+organizer:registration
+Grants the ability to manage the registrations of a tournament.
+organizer:permission
+Grants the ability to manage the permissions of a tournament.
+organizer:delete
+Grants the ability to delete tournaments.
+*/
+function getAccessTokenScope($api_client_id, $api_client_secret, $api_key, $scope) {
+
+    $json       = file_get_contents("access_token.json");
+    $token_data = json_decode($json, true);
+
+    if($token_data['date'] < (time() - (24 * 60 * 59))) {
+
+        // Get cURL resource
+        $curl = curl_init();
+        curl_setopt_array(
+            $curl, array(
+            CURLOPT_URL             => 'https://api.toornament.com/oauth/v2/token?scope='.$scope.'&grant_type=client_credentials&client_id='.$api_client_id.'&client_secret='.$api_client_secret,
+            CURLOPT_RETURNTRANSFER  => true,
+            CURLOPT_VERBOSE         => true,
+            CURLOPT_HEADER          => true,
+            CURLOPT_SSL_VERIFYPEER  => false,
+            CURLOPT_HTTPHEADER      => array(
+                'X-Api-Key: '.$api_key,
+                'Content-Type: application/json'
+            )
+        ));
+
+        $output         = curl_exec($curl);
+
+        $header_size    = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+        $header         = substr($output, 0, $header_size);
+        $body           = substr($output, $header_size);
+        $body           = json_decode($body);
+
+        if(isset($body->access_token)) {
+            $access_token   = $body->access_token;
+            file_put_contents("access_token.json", '{"access_token": "'.$access_token.'", "date": '.time().'}');
+        }
+
+    } else {
+        $access_token = $token_data['access_token'];
+    }
+
+    return @$access_token;
+}


### PR DESCRIPTION
Updating the application to use the v2 API - [v2 organizer_matches doc](https://developer.toornament.com/v2/doc/organizer_matches#patch:tournaments:tournament_id:matches:id)

We need specify a scope when calling the v2 API to request a proper access token 
[v2 scopes API doc](https://developer.toornament.com/v2/security/scopes)

In oauth.php, I created a new function called getAccessTokenScope that is the same as getAccessToken except it requires a scope to be called.  

In ajax.php we now call the getAccessTokenScope with:
`$scope = "organizer:result";`

When I have more time, next steps would be to use the proper scope for each call that's made from index.php. Have to think about the access_token.json that's stored locally here, as it changes depending on the scope that's requested. 
